### PR TITLE
Added support for environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@
 *.ipr
 *.iws
 .idea
+.classpath
+.settings/
 
 target/
 war/
 
 *.log
 .DS_Store
-

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Stack;
 
 public abstract class AbstractProcessMojo extends AbstractMojo {
@@ -16,6 +17,9 @@ public abstract class AbstractProcessMojo extends AbstractMojo {
     @Parameter (property = "exec.arguments")
     protected String[] arguments;
 
+    @Parameter (property = "exec.environment")
+    protected Map<String,String> environment;
+    
     @Parameter(property = "exec.workingDir")
     protected String workingDir;
 

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ExecProcess.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ExecProcess.java
@@ -9,6 +9,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
+import java.util.Map;
 
 public class ExecProcess {
     private Process process = null;
@@ -28,10 +29,13 @@ public class ExecProcess {
         return name;
     }
 
-    public void execute(File workingDirectory, Log log, String... args) {
+    public void execute(File workingDirectory, Log log, Map<String, String> environment, String... args) {
         final ProcessBuilder pb = new ProcessBuilder();
         log.info("Using working directory for this process: " + workingDirectory);
         pb.directory(workingDirectory);
+        if( environment != null  ){
+        	pb.environment().putAll( environment );
+        }
         pb.command(args);
         try {
             process = pb.start();

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStartMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStartMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import java.io.File;
+import java.util.Map;
 
 @Mojo (name = "start", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
 public class ProcessStartMojo extends AbstractProcessMojo {
@@ -20,6 +21,11 @@ public class ProcessStartMojo extends AbstractProcessMojo {
         }
         for (String arg : arguments) {
             getLog().info("arg: " + arg);
+        }
+        if( environment != null ){
+        	for( Map.Entry<String,String> entry : environment.entrySet() ){
+                getLog().info("env: " + entry.getKey() +"=" + entry.getValue());
+        	}
         }
         getLog().info("Full command line: " + Joiner.on(" ").join(arguments));
         try {
@@ -38,7 +44,7 @@ public class ProcessStartMojo extends AbstractProcessMojo {
             exec.setProcessLogFile(new File(processLogFile));
         }
         getLog().info("Starting process: " + exec.getName());
-        exec.execute(processWorkingDirectory(), getLog(), arguments);
+        exec.execute(processWorkingDirectory(), getLog(), environment, arguments);
         CrossMojoState.addProcess(exec, getPluginContext());
         ProcessHealthCondition.waitSecondsUntilHealthy(healthcheckUrl, waitAfterLaunch);
         getLog().info("Started process: " + exec.getName());

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStopMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStopMojo.java
@@ -6,6 +6,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Stack;
 
 @Mojo (name = "stop-all", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
@@ -16,6 +17,11 @@ public class ProcessStopMojo extends AbstractProcessMojo {
             throws MojoExecutionException, MojoFailureException {
         for(String arg : arguments) {
             getLog().info("arg: " + arg);
+        }
+        if( environment != null ){
+        	for( Map.Entry<String,String> entry : environment.entrySet() ){
+                getLog().info("env: " + entry.getKey() +"=" + entry.getValue());
+        	}
         }
         try {
             stopAllProcesses();


### PR DESCRIPTION
Please consider this pull request, adding support for specifying environment variables for the processes that are started. I have tested this locally in my build and it allows for me to specify env vars when starting a process.

Also, added .gitignore entries to ignore Eclipse .classpath and .settings
