### PR TITLE
Added possibility to add headers to the healthcheck request

### DIFF
--- a/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
@@ -7,6 +7,9 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Properties;
 import java.util.Stack;
 
 public abstract class AbstractProcessMojo extends AbstractMojo {
@@ -22,8 +25,13 @@ public abstract class AbstractProcessMojo extends AbstractMojo {
     @Parameter(property = "exec.name")
     protected String name;
 
-    @Parameter(property = "exec.healthcheckUrl")
-    protected String healthcheckUrl;
+    @Parameter(defaultValue = "${exec.healthcheckUrl}")
+    protected HealthcheckUrl healthcheckUrl;
+
+    public void setHealthcheckUrl(String url) throws MalformedURLException {
+        this.healthcheckUrl = new HealthcheckUrl();
+        this.healthcheckUrl.setUrl(new URL(url));
+    }
 
     @Parameter(property = "exec.waitAfterLaunch", required = false, defaultValue = "30")
     protected int waitAfterLaunch;

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/HealthcheckUrl.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/HealthcheckUrl.java
@@ -1,0 +1,23 @@
+package com.bazaarvoice.maven.plugin.process;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.net.URL;
+import java.util.Properties;
+
+public class HealthcheckUrl {
+    private URL url;
+    private Properties headers;
+
+    public URL getUrl() {
+        return url;
+    }
+
+    public Properties getHeaders() {
+        return headers;
+    }
+
+    public void setUrl(URL url) {
+        this.url = url;
+    }
+}


### PR DESCRIPTION
Usable for instance for authenticating health check requests. I need it for the pact_mock-service which expects a certain header to respond. 