### PR TITLE
Close input streams to fix redirector test on Windows

### DIFF
--- a/src/test/java/com/bazaarvoice/maven/plugin/process/StdOutRedirectorTest.java
+++ b/src/test/java/com/bazaarvoice/maven/plugin/process/StdOutRedirectorTest.java
@@ -96,6 +96,9 @@ public class StdOutRedirectorTest {
         while ((nread = expectedFileInputStream.read(dataBytes)) != -1) {
             expectedMD.update(dataBytes, 0, nread);
         };
+        
+        actualFileInputStream.close();
+        expectedFileInputStream.close();
 
         assertEquals(actualMD.getDigestLength(), expectedMD.getDigestLength());
         assertEquals(actualMD.digest(), expectedMD.digest());


### PR DESCRIPTION
On Windows the unit tests failed before, since the output files cannot be removed before the input streams have been closed.
This PR fixes the tests on Windows.