### PR TITLE
Fix ClassDefNotFoundErrors in shutdown hook

### DIFF
--- a/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
@@ -56,6 +56,9 @@ public abstract class AbstractProcessMojo extends AbstractMojo {
     }
 
     public AbstractProcessMojo() {
+    	// make sure CrossMojoState class is loaded to avoid NoClassDefFoundErrors
+    	CrossMojoState.getProcesses(getPluginContext());
+    	
         Runtime.getRuntime().addShutdownHook(new Thread() {
             public void run() {
                 Stack<ExecProcess> processesStack = CrossMojoState.getProcesses(getPluginContext());

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/CrossMojoState.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/CrossMojoState.java
@@ -13,6 +13,8 @@ public class CrossMojoState {
 
     @SuppressWarnings("unchecked")
     public static Stack<ExecProcess> getProcesses(Map pluginContext) {
+    	if(pluginContext == null) return null;
+    	
         Stack<ExecProcess> processes = (Stack<ExecProcess>) pluginContext.get(PROCESSES);
         if (processes == null) {
             processes = new Stack<ExecProcess>();


### PR DESCRIPTION
Make sure CrossMojoState class is loaded when the mojo is instantiated.
Otherwise if the CrossMojoState class has not been referenced before
anything goes wrong, the shutdownhook will cause a NoClassDefFoundError.