### PR TITLE
Convert workingDirectory parameter type to file

### DIFF
--- a/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
@@ -17,7 +17,7 @@ public abstract class AbstractProcessMojo extends AbstractMojo {
     protected String[] arguments;
 
     @Parameter(property = "exec.workingDir")
-    protected String workingDir;
+    protected File workingDir;
 
     @Parameter(property = "exec.name")
     protected String name;

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStartMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStartMojo.java
@@ -46,16 +46,10 @@ public class ProcessStartMojo extends AbstractProcessMojo {
 
     private File processWorkingDirectory() {
         if (workingDir == null) {
-            return ensureDirectory(new File(project.getBuild().getDirectory()));
+        	workingDir = new File(project.getBuild().getDirectory());
         }
-
-        // try to check if directory is absolute
-        // https://github.com/bazaarvoice/maven-process-plugin/issues/11
-        File potentialWorkingDir = new File(workingDir);
-        if (potentialWorkingDir.isAbsolute() && potentialWorkingDir.exists() && potentialWorkingDir.isDirectory()) {
-            return potentialWorkingDir;
-        }
-        return ensureDirectory(new File(project.getBuild().getDirectory(), workingDir));
+        
+        return ensureDirectory(workingDir);
     }
 
 }


### PR DESCRIPTION
Using a file parameter makes the use of absolute or relative paths more
consistent across different platforms.

Previously, using the expression ${project.build.directory} for the
parameter caused errors on Windows systems.
Also, the previous implementation did not handle relative paths
consistently, since relative paths needed to exist beforehand and would
not automatically be created by the plugin.