### PR TITLE
Add redirect of error stream (stderr to stdout)

### DIFF
--- a/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
@@ -37,6 +37,9 @@ public abstract class AbstractProcessMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", property = "exec.skip")
     protected boolean skip;
 
+    @Parameter(defaultValue = "false", property = "exec.redirectErrorStream")
+    protected boolean redirectErrorStream;
+
     protected static File ensureDirectory(File dir) {
         if (!dir.mkdirs() && !dir.isDirectory()) {
             throw new RuntimeException("couldn't create directories: " + dir);

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ExecProcess.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ExecProcess.java
@@ -14,7 +14,9 @@ public class ExecProcess {
     private Process process = null;
     private final List<StdoutRedirector> redirectors = Lists.newArrayList();
     private File processLogFile = null;
+    private boolean redirectErrorStream;
     private final String name;
+    final ProcessBuilder pb = new ProcessBuilder();
 
     public ExecProcess(String name) {
         this.name = name;
@@ -24,12 +26,22 @@ public class ExecProcess {
         this.processLogFile = emoLogFile;
     }
 
+    public void setRedirectErrorStream(boolean isRedirect) {
+        this.redirectErrorStream  = isRedirect;
+    }
+
     public String getName() {
         return name;
     }
 
     public void execute(File workingDirectory, Log log, String... args) {
         final ProcessBuilder pb = new ProcessBuilder();
+
+        if(redirectErrorStream) {
+            pb.redirectErrorStream(true);
+            pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        }
+
         log.info("Using working directory for this process: " + workingDirectory);
         pb.directory(workingDirectory);
         pb.command(args);

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStartMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStartMojo.java
@@ -37,6 +37,9 @@ public class ProcessStartMojo extends AbstractProcessMojo {
         if (null != processLogFile) {
             exec.setProcessLogFile(new File(processLogFile));
         }
+
+        exec.setRedirectErrorStream(redirectErrorStream);
+
         getLog().info("Starting process: " + exec.getName());
         exec.execute(processWorkingDirectory(), getLog(), arguments);
         CrossMojoState.addProcess(exec, getPluginContext());


### PR DESCRIPTION
We've faced the issue that if runs docker-compose in process plugin we get errors in output. It looks like docker-compose always posts to stderr for output of what is happening. Ideally we should just redirect stderr to stdout and be done with it but the maven plugin does not support redirection yet. I would like to add that functionality. Upon completion that should give us the option to add this to the config:

<configuration>
  <redirectErrorStream>true</redirectErrorStream>
...
That will remove the false errors from docker-compose. The negative side effect is any real errors will be posted via stdout. Which I'd rather live with instead of seeing ERROR in the logs.