### PR TITLE
Update maven plugin plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>${mavenVersion}</version>
+                <version>3.6.0</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>


### PR DESCRIPTION
Updated the plugin plugin version due to errors when cutting a release. The javadoc generation fails due to illegal comments. The illegal comments are from the generated code. This is fixed in a later version of the plugin.